### PR TITLE
Implement executable segment in code directory

### DIFF
--- a/ldid.cpp
+++ b/ldid.cpp
@@ -828,6 +828,9 @@ class FatHeader :
 #define CS_HASHTYPE_SHA256_160 3
 #define CS_HASHTYPE_SHA386_386 4
 
+#define CS_EXECSEG_MAIN_BINARY      0x1
+#define CS_EXECSEG_ALLOW_UNSIGNED   0x10
+
 struct BlobIndex {
     uint32_t type;
     uint32_t offset;
@@ -861,6 +864,9 @@ struct CodeDirectory {
     uint32_t teamIDOffset;
     uint32_t spare3;
     uint64_t codeLimit64;
+    uint64_t execSegBase;
+    uint64_t execSegLimit;
+    uint64_t execSegFlags;
 } _packed;
 
 #ifndef LDID_NOFLAGT
@@ -1099,7 +1105,7 @@ std::string Analyze(const void *data, size_t size) {
     return entitlements;
 }
 
-static void Allocate(const void *idata, size_t isize, std::streambuf &output, const Functor<size_t (const MachHeader &, size_t)> &allocate, const Functor<size_t (const MachHeader &, std::streambuf &output, size_t, const std::string &, const char *, const Functor<void (double)> &)> &save, const Functor<void (double)> &percent) {
+static void Allocate(const void *idata, size_t isize, std::streambuf &output, const Functor<size_t (const MachHeader &, size_t)> &allocate, const Functor<size_t (const MachHeader &, std::streambuf &output, size_t, size_t, const std::string &, const char *, const Functor<void (double)> &)> &save, const Functor<void (double)> &percent) {
     FatHeader source(const_cast<void *>(idata), isize);
 
     size_t offset(0);
@@ -1199,6 +1205,7 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
         position = allocation.offset_;
 
         std::vector<std::string> commands;
+        size_t execSegLimit = 0;
 
         _foreach (load_command, mach_header.GetLoadCommands()) {
             std::string copy(reinterpret_cast<const char *>(load_command), load_command->cmdsize);
@@ -1210,8 +1217,12 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
 
                 case LC_SEGMENT: {
                     auto segment_command(reinterpret_cast<struct segment_command *>(&copy[0]));
-                    if (strncmp(segment_command->segname, "__LINKEDIT", 16) != 0)
+                    if (strncmp(segment_command->segname, "__TEXT", 7) == 0) {
+                        execSegLimit = segment_command->vmsize;
                         break;
+                    } else if (strncmp(segment_command->segname, "__LINKEDIT", 16) != 0) {
+                        break;
+                    }
                     size_t size(mach_header.Swap(allocation.limit_ + allocation.alloc_ - mach_header.Swap(segment_command->fileoff)));
                     segment_command->filesize = size;
                     segment_command->vmsize = Align(size, 1 << allocation.align_);
@@ -1219,8 +1230,12 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
 
                 case LC_SEGMENT_64: {
                     auto segment_command(reinterpret_cast<struct segment_command_64 *>(&copy[0]));
-                    if (strncmp(segment_command->segname, "__LINKEDIT", 16) != 0)
+                    if (strncmp(segment_command->segname, "__TEXT", 7) == 0) {
+                        execSegLimit = segment_command->vmsize;
                         break;
+                    } else if (strncmp(segment_command->segname, "__LINKEDIT", 16) != 0) {
+                        break;
+                    }
                     size_t size(mach_header.Swap(allocation.limit_ + allocation.alloc_ - mach_header.Swap(segment_command->fileoff)));
                     segment_command->filesize = size;
                     segment_command->vmsize = Align(size, 1 << allocation.align_);
@@ -1285,7 +1300,7 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
         pad(output, allocation.limit_ - allocation.size_);
         position += allocation.limit_ - allocation.size_;
 
-        size_t saved(save(mach_header, output, allocation.limit_, overlap, top, percent));
+        size_t saved(save(mach_header, output, allocation.limit_, execSegLimit, overlap, top, percent));
         if (allocation.alloc_ > saved)
             pad(output, allocation.alloc_ - saved);
         else
@@ -1674,8 +1689,9 @@ Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::st
         }
 
         return alloc;
-    }), fun([&](const MachHeader &mach_header, std::streambuf &output, size_t limit, const std::string &overlap, const char *top, const Functor<void (double)> &percent) -> size_t {
+    }), fun([&](const MachHeader &mach_header, std::streambuf &output, size_t limit, size_t execSegLimit, const std::string &overlap, const char *top, const Functor<void (double)> &percent) -> size_t {
         Blobs blobs;
+        uint64_t execSegFlags = 0;
 
         if (true) {
             std::stringbuf data;
@@ -1694,6 +1710,10 @@ Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::st
             std::stringbuf data;
             put(data, entitlements.data(), entitlements.size());
             insert(blobs, CSSLOT_ENTITLEMENTS, CSMAGIC_EMBEDDED_ENTITLEMENTS, data);
+            if (entitlements.find("<key>get-task-allow</key>") != std::string::npos) {
+                // TODO: parse entitlements, avoid cases where `get-task-allow` is false or appears elsewhere
+                execSegFlags = CS_EXECSEG_MAIN_BINARY | CS_EXECSEG_ALLOW_UNSIGNED;
+            }
         }
 
         Slots posts(slots);
@@ -1720,7 +1740,7 @@ Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::st
             uint32_t normal((limit + PageSize_ - 1) / PageSize_);
 
             CodeDirectory directory;
-            directory.version = Swap(uint32_t(0x00020200));
+            directory.version = Swap(uint32_t(0x00020400));
             directory.flags = Swap(uint32_t(0));
             directory.nSpecialSlots = Swap(special);
             directory.codeLimit = Swap(uint32_t(limit));
@@ -1733,6 +1753,9 @@ Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::st
             directory.scatterOffset = Swap(uint32_t(0));
             directory.spare3 = Swap(uint32_t(0));
             directory.codeLimit64 = Swap(uint64_t(0));
+            directory.execSegBase = Swap(uint64_t(0));
+            directory.execSegLimit = Swap(uint64_t(execSegLimit));
+            directory.execSegFlags = Swap(execSegFlags);
 
             uint32_t offset(sizeof(Blob) + sizeof(CodeDirectory));
 
@@ -1815,7 +1838,7 @@ Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::st
 static void Unsign(void *idata, size_t isize, std::streambuf &output, const Functor<void (double)> &percent) {
     Allocate(idata, isize, output, fun([](const MachHeader &mach_header, size_t size) -> size_t {
         return 0;
-    }), fun([](const MachHeader &mach_header, std::streambuf &output, size_t limit, const std::string &overlap, const char *top, const Functor<void (double)> &percent) -> size_t {
+    }), fun([](const MachHeader &mach_header, std::streambuf &output, size_t limit, size_t execSegLimit, const std::string &overlap, const char *top, const Functor<void (double)> &percent) -> size_t {
         return 0;
     }), percent);
 }


### PR DESCRIPTION
Previous attempt to use version 0x20400 failed because the CD structure was
not updated. This implements the executable segment info and works on iOS
14.2.

Additionally, the execSegFlags is set to `CS_EXECSEG_ALLOW_UNSIGNED` for the
main executable whenever the entitlement `get-task-allow` is seen. This
allows for bulletproof JIT to work on iOS 14.2.

Currently, the flag is set whenever `get-task-allow` is seen but a proper
implementation should parse the entitlement and check that the key is set
to true before setting the flag.